### PR TITLE
fix build for gcc 11.4.0

### DIFF
--- a/api_cpp/examples/thirdParty/cxxopts/cxxopts.hpp
+++ b/api_cpp/examples/thirdParty/cxxopts/cxxopts.hpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <limits>
 
 #ifdef __cpp_lib_optional
 #include <optional>


### PR DESCRIPTION
## Description

build error with gcc 11.4.0: error: ‘numeric_limits’ is not a member of ‘std’ in api_cpp/examples/thirdParty/cxxopts/cxxopts.hpp

## Version

KortexAPI : **kortex_api_cpp/2.6.0-r.3@kortex/stable**

running on Ubuntu22 in WSL2: 5.15.133.1-microsoft-standard-WSL2
gcc: 11.4.0
cmake: 3.22.1
conan: 1.66.0

## Steps to reproduce

1. clone repository: git clone https://github.com/Kinovarobotics/Kinova-kortex2_Gen3_G3L.git
2. follow conan install instructions from `api_cpp/examples/readme.md`
3. manual build:
```sh
 mkdir build  
 cd build  
 cmake ..
 make  
```

## fix

add `#include <limits>` to `api_cpp/examples/thirdParty/cxxopts/cxxopts.hpp`